### PR TITLE
add optional persistent storage to node module and browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .DS_Store
 coverage/
 ethlightjs.min.js
+persist/

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -4,39 +4,122 @@ var EC = require('elliptic').ec
 var ec = new EC('secp256k1')
 var Mnemonic = require('bitcore-mnemonic')
 
-var KeyStore = function(mnemonic, password) {
+// If node map storage to node-persist, if browser map storage to localStorage
+if (process.env.NODE_ENV === 'browser'){
+  var storage = window.localStorage
+} else {
+  var storage = require('node-persist')
+  storage.initSync()
+}
 
-    // Check if mnemonic is valid
+var KeyStore = function(persist, password, mnemonic) {
+
+    // Enforces singleton
+    if (typeof KeyStore.instance === 'object') {
+        return KeyStore.instance;
+    }
+
+    this.encSeed = null
+    this.hdIndex = 0;
+    this.encPrivKeys = {};
+    this.addresses = [];
+
+    var passwordExist = (typeof password !== 'undefined')
+    var mnemonicExist = (typeof mnemonic !== 'undefined')
+
+    if (passwordExist && mnemonicExist) {
+        this._constructFromMnemonic(mnemonic, password)
+    }
+
+    if (passwordExist && !mnemonicExist) {
+        this._constructFromGenSeed(password)
+    }
+
+    if (!passwordExist && !mnemonicExist) {
+        this._constructFromStorage()
+    }
+
+    if (persist) {
+        this._constructPersistentStorage()
+    }
+
+    KeyStore.instance = this
+
+    return this
+}
+
+KeyStore.prototype._constructFromMnemonic = function (mnemonic, password) {
     if (!Mnemonic.isValid(mnemonic, Mnemonic.Words.ENGLISH)){
       throw new Error("KeyStore: Invalid mnuemonic");
     }
 
     this.encSeed = KeyStore._encryptSeed(mnemonic, password);
-    this.hdIndex = 0;
-    this.encPrivKeys = {};
-    this.addresses = [];
+}
 
-    // Initialize KeyStore with an address
-    this.generateNewAddress(password);
+KeyStore.prototype._constructFromGenSeed = function (password) {
+    var mnemonic = KeyStore.generateRandomSeed()
+    this.encSeed = KeyStore._encryptSeed(mnemonic, password);
+}
+
+KeyStore.prototype._constructFromStorage = function () {
+    var item = storage.getItem('eljs.encSeed')
+
+    if (item === null || typeof item === 'undefined') {
+      throw new Error("KeyStore._constructFromStorage: No stored wallet exists");
+    }
+
+    this.encSeed = storage.getItem('eljs.encSeed')
+    this.hdIndex = storage.getItem('eljs.hdIndex')
+    this.encPrivKeys = storage.getItem('eljs.encPrivKeys')
+    this.addresses = storage.getItem('eljs.addresses')
+}
+
+KeyStore.prototype._constructPersistentStorage = function () {
+
+    // Set initial values to storage
+    this._saveToStorage()
+
+    var origGenerateNewAddress = KeyStore.prototype.generateNewAddress
+
+    // Modifies functions which change the object and saves them to storage
+    KeyStore.prototype.generateNewAddress = function() {
+        origGenerateNewAddress.apply(this, arguments);
+        this._saveToStorage()
+    }
+
+}
+
+KeyStore.prototype._saveToStorage = function () {
+    storage.setItem('eljs.encSeed', this.encSeed)
+    storage.setItem('eljs.hdIndex', this.hdIndex)
+    storage.setItem('eljs.encPrivKeys', this.encPrivKeys)
+    storage.setItem('eljs.addresses', this.addresses)
 }
 
 KeyStore._encryptSeed = function (seed, password) {
-    return CryptoJS.AES.encrypt(seed, password);
+    var encObj = CryptoJS.AES.encrypt(seed, password);
+    var encSeed = { 'seed': encObj.toString(),
+                    'iv': encObj.iv.toString(),
+                    'salt': encObj.salt.toString()}
+    return encSeed
 }
 
-KeyStore._decryptSeed = function (encryptedKey, password) {
-    var decryptedSeed = CryptoJS.AES.decrypt(encryptedKey, password);
+KeyStore._decryptSeed = function (encryptedSeed, password) {
+    var decryptedSeed = CryptoJS.AES.decrypt(encryptedSeed.seed, password, {'iv': encryptedSeed.iv, 'salt': encryptedSeed.salt });
     return decryptedSeed.toString(CryptoJS.enc.Latin1);
 }
 
 KeyStore._encryptKey = function (privKey, password) {
     var privKeyWordArray = CryptoJS.enc.Hex.parse(privKey)
-    var encryptedKey = CryptoJS.AES.encrypt(privKeyWordArray, password);
-    return encryptedKey;
+    var encKey = CryptoJS.AES.encrypt(privKeyWordArray, password);
+    var encKey = { 'seed': encKey.toString(),
+                    'iv': encKey.iv.toString(),
+                    'salt': encKey.salt.toString()}
+    return encKey
 }
 
 KeyStore._decryptKey = function (encryptedKey, password) {
-    var decryptedKey = CryptoJS.AES.decrypt(encryptedKey, password);
+    var decryptedKey = CryptoJS.AES.decrypt(encryptedKey.seed, password, {'iv': encryptedKey.iv, 'salt': encryptedKey.salt });
     return decryptedKey.toString(CryptoJS.enc.Hex);
 }
 
@@ -62,7 +145,6 @@ KeyStore.prototype._addPrivateKey = function (privKey, password) {
 }
 
 // External static functions
-
 KeyStore.generateRandomSeed = function() {
     var seed = new Mnemonic(Mnemonic.Words.ENGLISH)
     return seed.toString()
@@ -94,7 +176,7 @@ KeyStore.prototype.signTx = function (rawTx, password, signingAddress) {
     if (this.addresses.length === 0) {
         throw new Error("KeyStore.signTx: No private keys in KeyStore.")
     }
-    
+
     var address = ''
     if (signingAddress === undefined) {
         address = this.addresses[0]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A light weight ethereum javascript wallet.",
   "main": "index.js",
   "scripts": {
-    "build-js": "browserify index.js --s ethlightjs | uglifyjs -mc > ethlightjs.min.js",
+    "build-js": "browserify index.js --s ethlightjs -t [ envify --NODE_ENV browser ] | uglifyjs -mc > ethlightjs.min.js",
     "test": "./node_modules/.bin/mocha --reporter spec",
     "coverage": "istanbul cover _mocha -- -R spec; open coverage/lcov-report/index.html"
   },
@@ -39,12 +39,14 @@
     "crypto-js": "^3.1.5",
     "elliptic": "^3.1.0",
     "ethereumjs-tx": "^0.2.2",
+    "node-persist": "0.0.3",
     "rlp": "^1.0.0",
     "web3": "^0.6.0"
   },
   "devDependencies": {
     "browserify": "^10.2.4",
     "chai": "^3.0.0",
+    "envify": "^3.4.0",
     "istanbul": "^0.3.15",
     "mocha": "^2.2.5",
     "uglify-js": "^2.4.23"


### PR DESCRIPTION
Node module maps storage to https://github.com/simonlast/node-persist
When in browser storage maps to localStorage

Keystore construct interface (could use suggestions, can discuss what makes most sense). It unfortunately modifies what we have already used in examples.

```
//persistent = true to store keystore in persistent storage

// Creates new keystore with given mnemonic
new Keystore(persistent, password, mnemonic)  
 
// Creates new keystore and generate seed/mnemonic for you
new Keystore(persistent, password)

// Creates new keystore from persistent storage if exists
new Keystore(persistent)

 Creates new keystore from persistent storage if exists, default to not persist
new Keystore()
```
 
note: relevant tests not added yet, only tested through some examples