### PR TITLE
Changed password hashing scheme to PBKDF2

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -9,7 +9,7 @@ var KeyStore = function(mnemonic, password) {
 
     this.encSeed = undefined;
     this.encMasterPriv = undefined;
-    this.pwHash = undefined;
+    this.keyHash = undefined;
     this.salt = undefined;
     this.hdIndex = 0;
     this.encPrivKeys = {};
@@ -20,11 +20,12 @@ var KeyStore = function(mnemonic, password) {
         throw new Error("KeyStore: Invalid mnemonic");
       }
       this.salt = CryptoJS.lib.WordArray.random(128 / 8);
-      this.pwHash = CryptoJS.PBKDF2(password, this.salt, {keysize: 512 / 32, iterations: 1000}).toString();
+      var masterKey = CryptoJS.PBKDF2(password, this.salt, {keysize: 512 / 32, iterations: 500}).toString();
+      this.keyHash = CryptoJS.SHA3(masterKey).toString();
 
-      this.encSeed = KeyStore._encryptString(mnemonic, password);
+      this.encSeed = KeyStore._encryptString(mnemonic, masterKey);
       var master = new Mnemonic(mnemonic).toHDPrivateKey().xprivkey;
-      this.encMasterPriv = KeyStore._encryptString(master, password);
+      this.encMasterPriv = KeyStore._encryptString(master, masterKey);
     }
 }
 
@@ -68,17 +69,16 @@ KeyStore._computeAddressFromPrivKey = function (privKey) {
 }
 
 KeyStore.prototype._addKeyPair = function (privKey, address, password) {
-    var encPrivKey = KeyStore._encryptKey(privKey, password)
+    var masterKey = this.generateMKey(password)
+    var encPrivKey = KeyStore._encryptKey(privKey, masterKey)
 
     this.encPrivKeys[address] = encPrivKey
     this.addresses.push(address)
 }
 
 KeyStore.prototype._generatePrivKey = function(password) {
-    if (!this.validatePw(password)){
-        throw new Error("Keystore.generatePrivKey: Invalid Password");
-    }
-    var master = KeyStore._decryptString(this.encMasterPriv, password);
+    var masterKey = this.generateMKey(password)
+    var master = KeyStore._decryptString(this.encMasterPriv, masterKey);
     var key = new bitcore.HDPrivateKey(master).derive(this.hdIndex++);
 
     return key.privateKey.toString()
@@ -103,7 +103,8 @@ KeyStore.deserialize = function (keystore) {
     keystore.hdIndex = jsonKS.hdIndex
     keystore.encPrivKeys = jsonKS.encPrivKeys
     keystore.addresses = jsonKS.addresses
-
+    keystore.salt = jsonKS.salt
+    keystore.keyHash = jsonKS.keyHash
     return keystore
 }
 
@@ -114,7 +115,9 @@ KeyStore.prototype.serialize = function () {
                 "encMasterPriv": this.encMasterPriv,
                 "hdIndex": this.hdIndex,
                 "encPrivKeys": this.encPrivKeys,
-                "addresses": this.addresses}
+                "addresses": this.addresses,
+                "salt": this.salt,
+                "keyHash": this.keyHash}
 
     return JSON.stringify(jsonKS)
 }
@@ -124,10 +127,8 @@ KeyStore.prototype.getAddresses = function () {
 }
 
 KeyStore.prototype.getSeed = function (password) {
-    var seed = KeyStore._decryptString(this.encSeed, password);
-    if (!Mnemonic.isValid(seed, Mnemonic.Words.ENGLISH)){
-        throw new Error("Invalid Password");
-    }
+    var masterKey = this.generateMKey(password)
+    var seed = KeyStore._decryptString(this.encSeed, masterKey);
     return seed;
 }
 
@@ -136,7 +137,9 @@ KeyStore.prototype.exportPrivateKey = function (address, password) {
         throw new Error("KeyStore.exportPrivateKey: Address not found in KeyStore")
     }
     var encKey = this.encPrivKeys[address]
-    var privKey = KeyStore._decryptKey(encKey, password)
+    var masterKey = this.generateMKey(password)
+
+    var privKey = KeyStore._decryptKey(encKey, masterKey)
 
     return privKey;
 }
@@ -169,13 +172,12 @@ KeyStore.prototype.signTx = function (rawTx, password, signingAddress) {
         }
         address = signingAddress
     }
-    if (!this.validatePw(password)){
-        throw new Error("Keystore.signTx: Invalid Password");
-    }
 
     var txCopy = new Transaction(new Buffer(rawTx, 'hex'))
     var encPrivKey = this.encPrivKeys[address]
-    var privKey = KeyStore._decryptKey(encPrivKey, password)
+    var masterKey = this.generateMKey(password)
+
+    var privKey = KeyStore._decryptKey(encPrivKey, masterKey)
     var addrFromPrivKey = KeyStore._computeAddressFromPrivKey(privKey)
     if (addrFromPrivKey !== address) {
         throw new Error("KeyStore.signTx: Decrypting private key failed!")
@@ -186,9 +188,12 @@ KeyStore.prototype.signTx = function (rawTx, password, signingAddress) {
     return txCopy.serialize().toString('hex')
 }
 
-KeyStore.prototype.validatePw = function(password) {
-    var hash = CryptoJS.PBKDF2(password, this.salt, {keysize: 512 / 32, iterations: 1000}).toString();
-    return (hash === this.pwHash);
+KeyStore.prototype.generateMKey = function(password) {
+    var masterKey = CryptoJS.PBKDF2(password, this.salt, {keysize: 512 / 32, iterations: 500}).toString();
+    if (CryptoJS.SHA3(masterKey).toString() !== this.keyHash){
+      throw new Error('Invalid Password');
+    }
+    return masterKey
 }
 
 module.exports = KeyStore;


### PR DESCRIPTION
Keystore now uses 1000 iterations of PBKDF2 with a randomly
generated salt instead of a single instance of SHA3 for more
secure key stretching.
