### PR TITLE
Add batch address generation

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -65,10 +65,7 @@ KeyStore._computeAddressFromPrivKey = function (privKey) {
   return address;
 };
 
-KeyStore.prototype._addKeyPair = function (privKey, address, password) {
-  var encKey = this.generateEncKey(password);
-  var encPrivKey = KeyStore._encryptKey(privKey, encKey);
-
+KeyStore.prototype._addKeyPair = function (encPrivKey, address) {
   this.encPrivKeys[address] = encPrivKey;
   this.addresses.push(address);
 };
@@ -77,8 +74,29 @@ KeyStore.prototype._generatePrivKey = function(password) {
   var encKey = this.generateEncKey(password);
   var master = KeyStore._decryptString(this.encMasterPriv, encKey);
   var key = new bitcore.HDPrivateKey(master).derive(this.hdIndex++);
+  var encPrivKey = KeyStore._encryptKey(key.privateKey.toString(), encKey);
 
-  return key.privateKey.toString();
+  return {
+    privKey: key.privateKey.toString(),
+    encPrivKey: encPrivKey
+  }
+};
+
+KeyStore.prototype._generatePrivKeys = function(password, n) {
+  var encKey = this.generateEncKey(password);
+  var master = KeyStore._decryptString(this.encMasterPriv, encKey);
+  var keys = [];
+  for (var i = 0; i < n; i++){
+    var key = new bitcore.HDPrivateKey(master).derive(this.hdIndex++);
+    var encPrivKey = KeyStore._encryptKey(key.privateKey.toString(), encKey);
+
+    keys[i] = {
+      privKey: key.privateKey.toString(),
+      encPrivKey: encPrivKey
+    }
+  }
+
+  return keys;
 };
 
 // External static functions
@@ -141,14 +159,18 @@ KeyStore.prototype.exportPrivateKey = function (address, password) {
   return privKey;
 };
 
-KeyStore.prototype.generateNewAddress = function(password) {
+KeyStore.prototype.generateNewAddress = function(password, n) {
   if (!this.encSeed) {
     throw new Error('KeyStore.generateNewAddress: No seed set');
   }
+  n = n || 1;
+  var keys = this._generatePrivKeys(password, n);
 
-  var privateKey = this._generatePrivKey(password);
-  var address = KeyStore._computeAddressFromPrivKey(privateKey);
-  this._addKeyPair(privateKey, address, password);
+  for (var i = 0; i < n; i++){
+    var keyObj = keys[i];
+    var address = KeyStore._computeAddressFromPrivKey(keyObj.privKey);
+    this._addKeyPair(keyObj.encPrivKey, address);
+  }
 
   return address;
 };
@@ -184,7 +206,7 @@ KeyStore.prototype.signTx = function (rawTx, password, signingAddress) {
 };
 
 KeyStore.prototype.generateEncKey = function(password) {
-  var encKey = CryptoJS.PBKDF2(password, this.salt, { keySize: 512 / 32, iterations: 250 }).toString();
+  var encKey = CryptoJS.PBKDF2(password, this.salt, { keySize: 512 / 32, iterations: 150 }).toString();
   var hash = CryptoJS.SHA3(encKey).toString();
   if (this.keyHash === undefined){
     this.keyHash = hash;

--- a/test/keystore.js
+++ b/test/keystore.js
@@ -97,9 +97,7 @@ describe("Keystore", function() {
       var origKS = new keyStore(fixtures.valid[0].mnSeed, fixtures.valid[0].password)
 
       //Add Keys
-      for (i = 0; i < 20; i++) {
-        origKS.generateNewAddress(fixtures.valid[0].password)
-      }
+      origKS.generateNewAddress(fixtures.valid[0].password, 20)
 
       var serKS = origKS.serialize()
       var deserKS = keyStore.deserialize(serKS)


### PR DESCRIPTION
Addresses can be generated in batches, instead of
regenerating the encryption key each time when trying
to add multiple addresses. This is done through:

generateNewAddress(password, n)

Key derivation is now slightly faster too
