### PR TITLE
[Android: fix for samsung sm-t230nu 4.4.2 relating to nonstandard web…

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -77,7 +77,14 @@ var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
     }
 
     // Pad the seed to length 120 before encrypting
-    var paddedSeed = (' '.repeat(120) + mnemonic).slice(-120);
+		//@note: @bug: ' '.repeat(120) has issues on samsung android 4.4.2 sm-t230nu
+	    // var paddedSeed = (' '.repeat(120) + mnemonic).slice(-120);
+	var padStr = '';
+	for (var i = 0; i < 120; i++) {
+		padStr += ' ';
+	}
+
+    var paddedSeed = (padStr + mnemonic).slice(-120);
     this.encSeed = KeyStore._encryptString(paddedSeed, pwDerivedKey);
 
     // hdRoot is the relative root from which we derive the keys using
@@ -430,7 +437,10 @@ KeyStore.deriveKeyFromPassword = function(password, callback) {
   var interruptStep = 200;
 
   var cb = function(derKey) {
-    callback(null, Uint8Array.from(derKey));
+	//@note: @bug: Uint8Array.from() had an issue on samsung android 4.4.2 sm-t230nu
+    // callback(null, Uint8Array.from(derKey));
+	var uint8array = new Uint8Array(derKey)
+    callback(null, uint8array);
   }
 
   scrypt(password, salt, logN, r, dkLen, interruptStep, cb, null);


### PR DESCRIPTION
…view]

so, this was a weird one. android 5.0.1 basic webview component was broken, the fix for that was to actually update the webview on the google play store (weird right), then on our older tablet it broke when that was updated to the last 4.4.2 it supports.

digging into (I mean way into.. chrome rocks for being able to inspect webviews to this degree) the source, it turned out that these two functions were simply not being found. I was slightly more surprised with the repeat of the string, could have been some weird type conversion.


having these two changes made it work. also improved my natural tenacity metric++.



I had to browserify it to a level where I could inspect the source in the chrome debugger, which was a "browserify index.js -s lightwallet > lightwallet.js" sort of thing.

by the way, you guys should have a nice tutorial on how to get "browserify index.js -s lightwallet | uglifyjs -c > lightwallet.min.js" method as a one liner somewhere. I wasn't able to get it down to the same level that it was at before with the browserify + minification :)