### PR TITLE
Added eth_sign functions (signMsg, recoverAddress, concatSig)

### DIFF
--- a/lib/signing.js
+++ b/lib/signing.js
@@ -40,11 +40,23 @@ signMsg = function (keystore, pwDerivedKey, rawMsg, signingAddress, hdPathString
 
 module.exports.signMsg = signMsg;
 
-recoverMsg = function (rawMsg, v, r, s) {
+recoverAddress = function (rawMsg, v, r, s) {
 
   var msgHash = util.sha3(rawMsg);
 
   return util.pubToAddress(util.ecrecover(msgHash, v, r, s));
 };
 
-module.exports.recoverMsg = recoverMsg;
+module.exports.recoverAddress = recoverAddress;
+
+concatSig = function (v, r, s) {
+  r = util.fromSigned(r);
+  s = util.fromSigned(s);
+  v = util.bufferToInt(v);
+  r = util.toUnsigned(r).toString('hex');
+  s = util.toUnsigned(s).toString('hex');
+  v = util.stripHexPrefix(util.intToHex(v));
+  return util.addHexPrefix(r.concat(s, v).toString("hex"));
+};
+
+module.exports.concatSig = concatSig;

--- a/lib/signing.js
+++ b/lib/signing.js
@@ -22,3 +22,29 @@ signTx = function (keystore, pwDerivedKey, rawTx, signingAddress, hdPathString) 
 };
 
 module.exports.signTx = signTx;
+
+signMsg = function (keystore, pwDerivedKey, rawMsg, signingAddress, hdPathString) {
+
+  if (hdPathString === undefined) {
+    hdPathString = keystore.defaultHdPathString;
+  }
+
+  signingAddress = util.stripHexPrefix(signingAddress);
+
+  var msgHash = util.sha3(rawMsg);
+
+  var privKey = keystore.exportPrivateKey(signingAddress, pwDerivedKey, hdPathString);
+
+  return util.ecsign(msgHash, new Buffer(privKey, 'hex'));
+};
+
+module.exports.signMsg = signMsg;
+
+recoverMsg = function (rawMsg, v, r, s) {
+
+  var msgHash = util.sha3(rawMsg);
+
+  return util.pubToAddress(util.ecrecover(msgHash, v, r, s));
+};
+
+module.exports.recoverMsg = recoverMsg;

--- a/test/signing.js
+++ b/test/signing.js
@@ -68,9 +68,14 @@ describe("Signing", function () {
 
       var signedMsg = signing.signMsg(ks, pw, msg, addr)
 
-      var recoveredMsg = signing.recoverMsg(msg, signedMsg.v, signedMsg.r, signedMsg.s)
+      var recoveredAddress = signing.recoverAddress(msg, signedMsg.v, signedMsg.r, signedMsg.s)
 
-      expect(addr).to.equal(recoveredMsg.toString('hex'))
+      expect(addr).to.equal(recoveredAddress.toString('hex'))
+
+      var concatSig = signing.concatSig(signedMsg.v, signedMsg.r, signedMsg.s)
+      var expectedConcatSig = '0x7b518ee144b8facf3f21b1f97a6d1f8aea448934d89cf5570e92bcca4d375ab6080f17400eafad3c5808e064ee56cd45321382040fb299fa028ea3cddf3488151c'
+
+      expect(concatSig).to.equal(expectedConcatSig);
 
       done();
     });

--- a/test/signing.js
+++ b/test/signing.js
@@ -14,11 +14,11 @@ describe("Signing", function () {
       ks.generateNewAddress(pw)
       var addr = ks.getAddresses()[0]
       expect('0x' + addr).to.equal(fixtures.valid[0].ethjsTxParams.from)
-      
+
       var tx = new Transaction(fixtures.valid[0].ethjsTxParams)
       var rawTx = tx.serialize().toString('hex')
       expect(rawTx).to.equal(fixtures.valid[0].rawUnsignedTx)
-      
+
       var signedTx0 = signing.signTx(ks, pw, rawTx, addr);
       expect(signedTx0).to.equal(fixtures.valid[0].rawSignedTx)
 
@@ -51,6 +51,27 @@ describe("Signing", function () {
       var expectedTx = 'f861808080945e2abe3de708923e8425348005ee7fdd77e203cb8405f5e100801ca00a9a2486f65cab6c7819c82ee741f72d1acaab005642eef32f303696909fa64ea04e5d5e0e8d5f38704ac04faa1f91a9ee15a3ffcf158de342324d242b6acba819';
 
       expect(signedTx).to.equal(expectedTx);
+      done();
+    });
+
+  });
+
+  describe("signMsg", function() {
+    it('signs a message deterministically', function(done) {
+      var pw = Uint8Array.from(fixtures.valid[0].pwDerivedKey)
+      var ks = new keyStore(fixtures.valid[0].mnSeed, pw)
+      ks.generateNewAddress(pw)
+      var addr = ks.getAddresses()[0]
+      expect('0x' + addr).to.equal(fixtures.valid[0].ethjsTxParams.from)
+
+      var msg = "this is a message"
+
+      var signedMsg = signing.signMsg(ks, pw, msg, addr)
+
+      var recoveredMsg = signing.recoverMsg(msg, signedMsg.v, signedMsg.r, signedMsg.s)
+
+      expect(addr).to.equal(recoveredMsg.toString('hex'))
+
       done();
     });
 


### PR DESCRIPTION
Allows to create signatures of messages, validate message signers and concatenate signatures to produce the same output as eth_sign does.