### PR TITLE
Add missing var to variable declaration

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -67,7 +67,7 @@ var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
 
   this.ksData = {};
   this.ksData[hdPathString] = {};
-  pathKsData = this.ksData[hdPathString];
+  var pathKsData = this.ksData[hdPathString];
   pathKsData.info = {curve: 'secp256k1', purpose: 'sign'};
 
   this.encSeed = undefined;


### PR DESCRIPTION
One more missing `var` in the `keystore.js` module.