### PR TITLE
Added signMsgHash and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Signs a transaction with the private key corresponding to `signingAddress`.
 * `pwDerivedKey`: the users password derived key (Uint8Array)
 * `rawTx`: Hex-string defining an RLP-encoded raw transaction.
 * `signingAddress`: hex-string defining the address to send the transaction from.
-* `hdPathString`: (Optional) A path at which to create the encryption keys. 
+* `hdPathString`: (Optional) A path at which to create the encryption keys.
 
 #### Return value
 
@@ -167,7 +167,7 @@ Hex-string corresponding to the RLP-encoded raw transaction.
 
 ### `signing.signMsg(keystore, pwDerivedKey, rawMsg, signingAddress, hdPathString)`
 
-Signs a message with the private key corresponding to `signingAddress`.
+Creates and signs a sha3 hash of a message with the private key corresponding to `signingAddress`.
 
 #### Inputs
 
@@ -175,11 +175,39 @@ Signs a message with the private key corresponding to `signingAddress`.
 * `pwDerivedKey`: the users password derived key (Uint8Array)
 * `rawMsg`: Message to be signed
 * `signingAddress`: hex-string defining the address corresponding to the signing private key.
-* `hdPathString`: (Optional) A path at which to create the encryption keys. 
+* `hdPathString`: (Optional) A path at which to create the encryption keys.
 
 #### Return value
 
-Hex-string corresponding to the RLP-encoded raw transaction.
+Signed hash as signature object with v, r and s values.
+
+### `signing.signMsgHash(keystore, pwDerivedKey, msgHash, signingAddress, hdPathString)`
+
+Signs a sha3 message hash with the private key corresponding to `signingAddress`.
+
+#### Inputs
+
+* `keystore`: An instance of the keystore with which to sign the TX with.
+* `pwDerivedKey`: the users password derived key (Uint8Array)
+* `msgHash`: SHA3 hash to be signed
+* `signingAddress`: hex-string defining the address corresponding to the signing private key.
+* `hdPathString`: (Optional) A path at which to create the encryption keys.
+
+#### Return value
+
+Signed hash as signature object with v, r and s values.
+
+### `concatSig(signature)`
+
+Concatenates signature object to return signature as hex-string in the same format as `eth_sign` does.
+
+#### Inputs
+
+* `signature`: Signature object as returned from `signMsg` or ``signMsgHash`.
+
+#### Return value
+
+Concatenated signature object as hex-string.
 
 ### `recoverAddress(rawMsg, v, r, s)`
 

--- a/lib/signing.js
+++ b/lib/signing.js
@@ -1,8 +1,7 @@
-
 var Transaction = require("ethereumjs-tx")
 var util = require("ethereumjs-util")
 
-var signTx = function (keystore, pwDerivedKey, rawTx, signingAddress, hdPathString) {
+signTx = function (keystore, pwDerivedKey, rawTx, signingAddress, hdPathString) {
 
   if (hdPathString === undefined) {
     hdPathString = keystore.defaultHdPathString;
@@ -23,7 +22,14 @@ var signTx = function (keystore, pwDerivedKey, rawTx, signingAddress, hdPathStri
 
 module.exports.signTx = signTx;
 
-var signMsg = function (keystore, pwDerivedKey, rawMsg, signingAddress, hdPathString) {
+signMsg = function (keystore, pwDerivedKey, rawMsg, signingAddress, hdPathString) {
+  var msgHash = util.addHexPrefix(util.sha3(rawMsg).toString('hex'));
+  return this.signMsgHash(keystore, pwDerivedKey, msgHash, signingAddress, hdPathString);
+};
+
+module.exports.signMsg = signMsg;
+
+signMsgHash = function (keystore, pwDerivedKey, msgHash, signingAddress, hdPathString) {
 
   if (hdPathString === undefined) {
     hdPathString = keystore.defaultHdPathString;
@@ -31,16 +37,14 @@ var signMsg = function (keystore, pwDerivedKey, rawMsg, signingAddress, hdPathSt
 
   signingAddress = util.stripHexPrefix(signingAddress);
 
-  var msgHash = util.sha3(rawMsg);
-
   var privKey = keystore.exportPrivateKey(signingAddress, pwDerivedKey, hdPathString);
 
-  return util.ecsign(msgHash, new Buffer(privKey, 'hex'));
+  return util.ecsign(new Buffer(util.stripHexPrefix(msgHash), 'hex'), new Buffer(privKey, 'hex'));
 };
 
-module.exports.signMsg = signMsg;
+module.exports.signMsgHash = signMsgHash;
 
-var recoverAddress = function (rawMsg, v, r, s) {
+recoverAddress = function (rawMsg, v, r, s) {
 
   var msgHash = util.sha3(rawMsg);
 
@@ -49,7 +53,10 @@ var recoverAddress = function (rawMsg, v, r, s) {
 
 module.exports.recoverAddress = recoverAddress;
 
-var concatSig = function (v, r, s) {
+concatSig = function (signature) {
+  var v = signature.v;
+  var r = signature.r;
+  var s = signature.s;
   r = util.fromSigned(r);
   s = util.fromSigned(s);
   v = util.bufferToInt(v);


### PR DESCRIPTION
I added signMsgHash, which expects a hashed message as input (signMsg expects any message string).

signMsgHash and signMsg return a signature object with V, R, S. This signature object has to be concatenated with `concatSig`to retun the same as `eth_sign`. I updated the readme.