### PR TITLE
Make salt user configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ var secretSeed = lightwallet.keystore.generateRandomSeed();
 var password = prompt('Enter password for encryption', 'password');
 var salt = lightwallet.keystore.generateSalt(); // You can also provide your own salt.
 
-// If you do not provide a salt, it defaults to 'lightwalletSalt' for backwards-compatibility.
 lightwallet.keystore.deriveKeyFromPassword(password, salt, function (err, pwDerivedKey) {
 
 // This is the default recommended hdPathString value.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,13 @@ var secretSeed = lightwallet.keystore.generateRandomSeed();
 
 // the seed is stored encrypted by a user-defined password
 var password = prompt('Enter password for encryption', 'password');
-lightwallet.keystore.deriveKeyFromPassword(password, function (err, pwDerivedKey) {
+var salt = 'accountSpecificSalt' // Salt is optional but recommended.
+lightwallet.keystore.deriveKeyFromPassword(password, function (err, pwDerivedKey, salt) {
 
-var ks = new lightwallet.keystore(secretSeed, pwDerivedKey);
+// If providing an optional salt, the `hdPathString` is required.
+// This is the default value you can provide when using a salt:
+var hdPathString = "m/0'/0'/0'";
+var ks = new lightwallet.keystore(secretSeed, pwDerivedKey, hdPathString, salt);
 
 // generate five new address/private key pairs
 // the corresponding private keys are also encrypted
@@ -59,7 +63,8 @@ var addr = ks.getAddresses();
 // call.
 ks.passwordProvider = function (callback) {
   var pw = prompt("Please enter password", "Password");
-  callback(null, pw);
+  // You must include the salt here if you've included the salt elsewhere:
+  callback(null, pw, salt);
 };
 
 // Now set ks as transaction_signer in the hooked web3 provider
@@ -73,11 +78,11 @@ These are the interface functions for the keystore object. The keystore object h
 
 Note: Addresses and RLP encoded data are in the form of hex-strings. Hex-strings do not start with `0x`.
 
-### `keystore.deriveKeyFromPassword(password, callback)`
+### `keystore.deriveKeyFromPassword(password, [salt], callback)`
 
 Inputs the users password and generates a symmetric key of type `Uint8Array` that is used to encrypt/decrypt the keystore.
 
-### `keystore(seed, pwDerivedKey [,hdPathString])`
+### `keystore(seed, pwDerivedKey [,hdPathString] [,salt])`
 
 Constructor of the keystore object. The seed `seed` is encrypted with `pwDerivedKey` and stored encrypted in the keystore.
 
@@ -86,6 +91,7 @@ Constructor of the keystore object. The seed `seed` is encrypted with `pwDerived
 * words: string defining a 12-word seed according to [BIP39][]
 * pwDerivedKey: symmetric key to encrypt the seed (Uint8Array)
 * hdPathString: optional alternate HD derivation path to use
+* salt: optional value added to password to encrypt the seed.
 
 ### `keystore.isDerivedKeyCorrect(pwDerivedKey)`
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ Sample usage with hooked web3 provider:
 // generate a new BIP32 12-word seed
 var secretSeed = lightwallet.keystore.generateRandomSeed();
 
-// the seed is stored encrypted by a user-defined password
+// the seed is stored encrypted by a user-defined password and salt.
 var password = prompt('Enter password for encryption', 'password');
-var salt = 'accountSpecificSalt' // Salt is optional but recommended.
-lightwallet.keystore.deriveKeyFromPassword(password, function (err, pwDerivedKey, salt) {
+var salt = lightwallet.keystore.generateSalt(); // You can also provide your own salt.
 
-// If providing an optional salt, the `hdPathString` is required.
-// This is the default value you can provide when using a salt:
+// If you do not provide a salt, it defaults to 'lightwalletSalt' for backwards-compatibility.
+lightwallet.keystore.deriveKeyFromPassword(password, salt, function (err, pwDerivedKey) {
+
+// This is the default recommended hdPathString value.
 var hdPathString = "m/0'/0'/0'";
+// When specifying a salt, the hdPathString is required.
 var ks = new lightwallet.keystore(secretSeed, pwDerivedKey, hdPathString, salt);
 
 // generate five new address/private key pairs
@@ -63,8 +65,7 @@ var addr = ks.getAddresses();
 // call.
 ks.passwordProvider = function (callback) {
   var pw = prompt("Please enter password", "Password");
-  // You must include the salt here if you've included the salt elsewhere:
-  callback(null, pw, salt);
+  callback(null, pw);
 };
 
 // Now set ks as transaction_signer in the hooked web3 provider
@@ -84,14 +85,14 @@ Inputs the users password and generates a symmetric key of type `Uint8Array` tha
 
 ### `keystore(seed, pwDerivedKey [,hdPathString] [,salt])`
 
-Constructor of the keystore object. The seed `seed` is encrypted with `pwDerivedKey` and stored encrypted in the keystore.
+Constructor of the keystore object. The seed `seed` is encrypted with `pwDerivedKey` and stored encrypted in the keystore, and so is the salt.
 
 #### Inputs
 
 * words: string defining a 12-word seed according to [BIP39][]
 * pwDerivedKey: symmetric key to encrypt the seed (Uint8Array)
 * hdPathString: optional alternate HD derivation path to use
-* salt: optional value added to password to encrypt the seed.
+* salt: optional value added to password to generate the `pwDerivedKey`.
 
 ### `keystore.isDerivedKeyCorrect(pwDerivedKey)`
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ var secretSeed = lightwallet.keystore.generateRandomSeed();
 var password = prompt('Enter password for encryption', 'password');
 var salt = lightwallet.keystore.generateSalt(); // You can also provide your own salt.
 
+// The salt is optional for backwards-compatibility, but highly recommended.
 lightwallet.keystore.deriveKeyFromPassword(password, salt, function (err, pwDerivedKey) {
 
 // This is the default recommended hdPathString value.

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -12,6 +12,8 @@ var scrypt = require('scrypt-async');
 var encryption = require('./encryption');
 var signing = require('./signing');
 
+var defaultSalt = 'lightwalletSalt'
+
 function strip0x (input) {
   if (typeof(input) !== 'string') {
     return input;
@@ -57,7 +59,11 @@ function nacl_decodeHex(msgHex) {
 }
 
 
-var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
+var KeyStore = function(mnemonic, pwDerivedKey, hdPathString, salt) {
+
+  if (!salt) {
+    salt = defaultSalt
+  }
 
   this.defaultHdPathString = "m/0'/0'/0'";
 
@@ -65,7 +71,7 @@ var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
     hdPathString = this.defaultHdPathString;
   }
   else {
-    this.defaultHdPathString = hdPathString;    
+    this.defaultHdPathString = hdPathString;
   }
 
   this.ksData = {};
@@ -490,9 +496,17 @@ KeyStore.prototype.getPubKeys = function (hdPathString) {
   return this.ksData[hdPathString].pubKeys;
 }
 
-KeyStore.deriveKeyFromPassword = function(password, callback) {
+KeyStore.deriveKeyFromPassword = function(password, salt, callback) {
 
-  var salt = 'lightwalletSalt'; // should we have user-defined salt?
+  // Do not require salt, and default it to 'lightwalletSalt'
+  // (for backwards compatibility)
+  if (!callback && typeof salt === 'function') {
+    callback = salt
+    salt = defaultSalt
+  } else if (!salt && typeof callback === 'function') {
+    salt = defaultSalt
+  }
+
   var logN = 14;
   var r = 8;
   var dkLen = 32;
@@ -564,9 +578,13 @@ KeyStore.prototype.signTransaction = function (txParams, callback) {
   var rawTx = txObj.serialize().toString('hex');
   var signingAddress = strip0x(txParams.from);
   var self = this;
-  this.passwordProvider( function (err, password) {
+  this.passwordProvider( function (err, password, salt) {
     if (err) return callback(err);
-    KeyStore.deriveKeyFromPassword(password, function (err, pwDerivedKey) {
+
+    if (!salt) {
+      salt = defaultSalt
+    }
+    KeyStore.deriveKeyFromPassword(password, salt, function (err, pwDerivedKey) {
       if (err) return callback(err);
       var signedTx = signing.signTx(self, pwDerivedKey, rawTx, signingAddress, self.defaultHdPathString);
       callback(null, '0x' + signedTx);

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -63,9 +63,12 @@ var KeyStore = function(mnemonic, pwDerivedKey, hdPathString, salt) {
 
   // The user can optionally specify their own salt,
   // otherwise it is randomly generated.
+  // Since it's the fourth argument, specifying it
+  // requires a specified hdPathString too.
   if (salt === undefined) {
-    this.salt = bitcore.crypto.Random.getRandomBuffer(12).toString('base64');
+    salt = defaultSalt
   }
+  this.salt = salt
 
   this.defaultHdPathString = "m/0'/0'/0'";
 
@@ -500,6 +503,11 @@ KeyStore.prototype.getPubKeys = function (hdPathString) {
   return this.ksData[hdPathString].pubKeys;
 }
 
+function generateSalt (byteCount) {
+  return bitcore.crypto.Random.getRandomBuffer(byteCount || 12).toString('base64');
+}
+KeyStore.generateSalt = generateSalt
+
 KeyStore.deriveKeyFromPassword = function(password, salt, callback) {
 
   // Do not require salt, and default it to 'lightwalletSalt'
@@ -581,13 +589,11 @@ KeyStore.prototype.signTransaction = function (txParams, callback) {
   var txObj = new Transaction(ethjsTxParams);
   var rawTx = txObj.serialize().toString('hex');
   var signingAddress = strip0x(txParams.from);
+  var salt = this.salt || defaultSalt;
   var self = this;
-  this.passwordProvider( function (err, password, salt) {
+  this.passwordProvider( function (err, password) {
     if (err) return callback(err);
 
-    if (!salt) {
-      salt = defaultSalt
-    }
     KeyStore.deriveKeyFromPassword(password, salt, function (err, pwDerivedKey) {
       if (err) return callback(err);
       var signedTx = signing.signTx(self, pwDerivedKey, rawTx, signingAddress, self.defaultHdPathString);

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -61,8 +61,10 @@ function nacl_decodeHex(msgHex) {
 
 var KeyStore = function(mnemonic, pwDerivedKey, hdPathString, salt) {
 
-  if (!salt) {
-    salt = defaultSalt
+  // The user can optionally specify their own salt,
+  // otherwise it is randomly generated.
+  if (salt === undefined) {
+    this.salt = bitcore.crypto.Random.getRandomBuffer(12).toString('base64');
   }
 
   this.defaultHdPathString = "m/0'/0'/0'";
@@ -354,6 +356,7 @@ KeyStore.deserialize = function (keystore) {
   keystoreX.encSeed       = jsonKS.encSeed;
   keystoreX.encHdRootPriv = jsonKS.encHdRootPriv;
   keystoreX.ksData        = jsonKS.ksData;
+  keystoreX.salt          = jsonKS.salt || defaultSalt;
 
   // Set the defaultHdPathString to an entry that is actuall in the
   // deserialized key store, otherwise the keystore will operate with
@@ -370,6 +373,7 @@ KeyStore.prototype.serialize = function () {
   var jsonKS = {'encSeed': this.encSeed,
                 'ksData' : this.ksData,
                 'encHdRootPriv' : this.encHdRootPriv,
+                'salt': this.salt || defaultSalt,
                 'version' : this.version};
 
   return JSON.stringify(jsonKS);

--- a/test/fixtures/keystore.json
+++ b/test/fixtures/keystore.json
@@ -3,6 +3,7 @@
     {"password" : "password",
      "salt": "strangeSalt",
      "pwDerivedKey": [205, 127, 41, 55, 40, 243, 95, 138, 187, 239, 244, 242, 33, 239, 174, 4, 146, 184, 75, 185, 221, 160, 223, 207, 124, 49, 16, 208, 237, 141, 15, 120],
+
       "seed": "77c2b00716cec7213839159e404db50d",
       "mnSeed": "jelly better achieve collect unaware mountain thought cargo oxygen act hood bridge",
       "hdIndex": 0,

--- a/test/fixtures/keystore.json
+++ b/test/fixtures/keystore.json
@@ -1,6 +1,54 @@
 {
   "valid": [
     {"password" : "password",
+     "salt": "strangeSalt",
+     "pwDerivedKey": [205, 127, 41, 55, 40, 243, 95, 138, 187, 239, 244, 242, 33, 239, 174, 4, 146, 184, 75, 185, 221, 160, 223, 207, 124, 49, 16, 208, 237, 141, 15, 120],
+      "seed": "77c2b00716cec7213839159e404db50d",
+      "mnSeed": "jelly better achieve collect unaware mountain thought cargo oxygen act hood bridge",
+      "hdIndex": 0,
+      "privKeyHex": "7627f5655d3f103f0be5c90064bd3557995604e6208590986de4e1230425c1ae",
+      "address": "07ed7f762488ffa46298afeba33f05a04c796833",
+     "ethjsTxParams" : {"from" : "0x07ed7f762488ffa46298afeba33f05a04c796833",
+                        "to" : "0x9e2068cce22de4e1e80f15cb71ef435a20a3b37c",
+                        "nonce" : "0x00",
+                        "value" : "0xde0b6b3a7640000",
+                        "gasLimit" : "0x2fefd8",
+                        "gasPrice" : "0xba43b7400",
+                       "data" : "0xabcdef01234567890"},
+     "web3TxParams" : {"from" : "0x07ed7f762488ffa46298afeba33f05a04c796833",
+                        "to" : "0x9e2068cce22de4e1e80f15cb71ef435a20a3b37c",
+                        "nonce" : "0x00",
+                        "value" : "0xde0b6b3a7640000",
+                        "gas" : "0x2fefd8",
+                        "gasPrice" : "0xba43b7400",
+                       "data" : "0xabcdef01234567890"},
+     "rawUnsignedTx" : "f680850ba43b7400832fefd8949e2068cce22de4e1e80f15cb71ef435a20a3b37c880de0b6b3a7640000890abcdef012345678901c8080",
+     "rawSignedTx" : "f87680850ba43b7400832fefd8949e2068cce22de4e1e80f15cb71ef435a20a3b37c880de0b6b3a7640000890abcdef012345678901ca08de63b51b4b9cc5bc09f7f9610d707f43c5840b37dffe655d0073b270032511ba01c31647c5cb6d32676e73bd0ea618fa9f3fa2a7c0132e11a593b2e44cc500323",
+      "m/0'/0'/1'" : {"addresses" : [ "d540ec8e4de76484e31cdce612f1d4da196e6987",
+                                      "f65f355fd6c0771a9fa9dc31191dcafe1cc79934",
+                                      "1fb2a56e077aa64236623baea6fae20c6209d885",
+                                      "3c2b55c8019eec2ceea5154cc6d150e877a68a69",
+                                      "ee77f5a7f61ff11b8734c043db0ed5bc7afd8447" ]},
+
+      "m/0'/0'/5'" : {"addresses" : [ "427bfa1ebd65dd5a136ed3112fe5f72e7cebe43a",
+                                      "a4c2f35340307e50b453ccd6574db054d2ef357a",
+                                      "618c683268c1c2a75f28e158943977e81b7568a1",
+                                      "060e9bb7211af94a13f2d09cec767d5d2ca4acc1",
+                                      "558e33b4272da4b004470a4ada4e673cc972379a",
+                                      "6b85cc8f612d5457d49775439335f83e12b8cfde",
+                                      "cbd22ff1ded1423fbc24a7af2148745878800024" ]},
+
+     "m/0'/0'/2'" : {"pubKeys" : ["9b2b6699ad63eaf4f08c5a16d29eaf9db40dfb47b6c41d16bb00368564b76f10",
+                                  "eaa70a8727385e6e0af7ce718874065a3cba0b994555543288b79901e320be20",
+                                  "70d505a34e1ff438a6e0fca3ba37ba8e3c7d7b9843a5762b45d3be9e4d38633f",
+                                  "7c2864ef868146251c881d2cb4e92cab3a1868bb3fc49b233a4471dcb1bc050e",
+                                  "9c493f840b54cb4d48c1dbc8dacf4b7fa6a471e4f462eae3f64ebf10fcd9430c",
+                                  "170023f3a4ef99ae36f97bfedb8e55be277755a2b1b8caa35067cfe93e467b1d" ]}
+     
+
+    },
+    {"password" : "password",
+     "salt": "lightwalletSalt",
      "pwDerivedKey" : [12, 37, 184, 176, 141, 255, 15, 70, 189, 195, 206, 218, 109, 172, 141, 233, 117, 114, 2, 10, 156, 57, 255, 102, 37, 66, 2, 177, 82, 70, 1, 246],
 
       "seed": "77c2b00716cec7213839159e404db50d",
@@ -49,6 +97,7 @@
     },
 
     {"password" : "asdflknwqeroilasdflkjnzvmnwmet",
+     "salt": "lightwalletSalt",
      "pwDerivedKey" : [24,100,147,66,23,117,206,186,27,54,254,137,187,174,103,5,38,18,139,128,139,74,217,188,166,34,0,30,54,133,158,208],
       "seed": "0460ef47585604c5660618db2e6a7e7f",
       "mnSeed": "afford alter spike radar gate glance object seek swamp infant panel yellow",
@@ -58,6 +107,7 @@
     },
 
     {"password" : "!@&#*#()",
+     "salt": "lightwalletSalt",
      "pwDerivedKey" : [51,238,218,224,61,216,29,19,249,245,254,125,54,245,160,253,1,73,137,234,137,138,109,226,61,11,128,41,76,115,80,43],
       "seed": "eaebabb2383351fd31d703840b32e9e2",
       "mnSeed": "turtle front uncle idea crush write shrug there lottery flower risk shell",
@@ -68,6 +118,7 @@
 
     {
       "password" : "PassHello",
+      "salt": "lightwalletSalt",
       "pwDerivedKey" : [113,91,117,133,102,129,128,16,251,116,91,122,215,255,183,202,72,108,222,129,238,46,143,236,132,13,127,227,110,202,254,112],
       "seed": "18ab19a9f54a9274f03e5209a2ac8a91",
       "mnSeed": "board flee heavy tunnel powder denial science ski answer betray cargo cat",
@@ -98,6 +149,5 @@
       "ent1" : "c",
       "targetHash" : "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
     }
-    
   ]
 }

--- a/test/keystore.js
+++ b/test/keystore.js
@@ -36,9 +36,9 @@ describe("Keystore", function() {
       done();
     })
 
-    it("generates a random 16 character salt", function(done) {
+    it("salt defaults to original value for backwards-compatibility", function(done) {
       var ks = new keyStore(fixtures.valid[0].mnSeed, Uint8Array.from(fixtures.valid[0].pwDerivedKey))
-      expect(ks.salt.length).to.equal(16)
+      expect(ks.salt).to.equal('lightwalletSalt')
       done();
     })
 
@@ -90,6 +90,21 @@ describe("Keystore", function() {
         expect(decryptedKey).to.equal(f.privKeyHex)
         done();
       })
+    })
+  });
+
+  describe("generateSalt", function () {
+    it("generates a different 16-character salt each time", function() {
+      var salt, salts = [];
+      for (var i = 0; i < 10; i++) {
+        salt = keyStore.generateSalt()
+        expect(salt.length).to.equal(16)
+
+        salts.forEach(function (otherSalt) {
+          expect(salt).not.to.equal(otherSalt)
+        })
+        salts.push(salt)
+      }
     })
   });
 


### PR DESCRIPTION
Fixes #109

Added an optional `salt` attribute to relevant methods:
- `deriveKeyFromPassword(password, [salt,] cb)`
- `passwordProvider` should now also provide a `salt` if a `salt` was initially used.
- `KeyStore` constructor. Since `hdPathString` was already optional, it is now mandatory when a `salt` is provided, which is a sad effect of having the same input types. This is why I like using `options` objects instead of ordered arguments.  I'm open to alternative backwards-compatible solutions to this.