### PR TITLE
prevent double callback in case of error

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -65,7 +65,7 @@ var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
     hdPathString = this.defaultHdPathString;
   }
   else {
-    this.defaultHdPathString = hdPathString;    
+    this.defaultHdPathString = hdPathString;
   }
 
   this.ksData = {};
@@ -499,12 +499,14 @@ KeyStore.deriveKeyFromPassword = function(password, callback) {
   var interruptStep = 200;
 
   var cb = function(derKey) {
-    try{
+    var err
+    try {
       var ui8arr = (new Uint8Array(derKey));
-      callback(null, ui8arr);
-    } catch (err) {
-      callback(err);
+    } catch (e) {
+      err = e
     }
+
+    callback(err, ui8arr);
   }
 
   scrypt(password, salt, logN, r, dkLen, interruptStep, cb, null);


### PR DESCRIPTION
the try/catch shouldn't catch errors in the callback function, otherwise weird side effects arise, e.g. if:

```js
ks.deriveKeyFromPassword('badpassword', function badCallback () {
  throw new Error('misbehavin!') // causes badCallback to get called again
})
```

