### PR TITLE
New vault constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ Adds the HD derivation path `hdPathString` to the keystore. The `info` structure
 
 Set the default HD Derivation path. This path will be used if the `hdPathString` is omitted from other functions. This is also the path that's used if the keystore is used with the Hooked Web3 Provider.
 
-### `keystore.generateNewAddress([pwDerivedKey], num, [hdPathString])`
+### `keystore.generateNewAddress(pwDerivedKey, [num,] [hdPathString])`
 
-The simplest usage is `ks.generateNewAddress(quantityToGenerate)`.
+Allows the vault to generate additional internal address/private key pairs.
 
-Generates `num` new address/private key pairs in the keystore from the seed phrase, which will be returned with calls to `ks.getAddresses()`.
+The simplest usage is `ks.generateNewAddress(pwDerivedKey)`.
 
-To support backwards compatibility, you may optionally include the `pwDerivedKey` as the first argument, and the `hdPathString` as the third argument.
+Generates `num` new address/private key pairs (defaults to 1) in the keystore from the seed phrase, which will be returned with calls to `ks.getAddresses()`.
 
 ### `keystore.deserialize(serialized_keystore)`
 

--- a/README.md
+++ b/README.md
@@ -51,22 +51,29 @@ keyStore.createVault({
   // hdPathString: hdPath    // Optional custom HD Path String
 }, function (err, ks) {
 
-  // generate five new address/private key pairs
-  // the corresponding private keys are also encrypted
-  ks.generateNewAddress(pwDerivedKey, 5);
-  var addr = ks.getAddresses();
+  // Some methods will require providing the `pwDerivedKey`,
+  // Allowing you to only decrypt private keys on an as-needed basis.
+  // You can generate that value with this convenient method:
+  ks.keyFromPassword(password, function (err, pwDerivedKey) {
+    if (err) throw err;
 
-  ks.passwordProvider = function (callback) {
-    var pw = prompt("Please enter password", "Password");
-    callback(null, pw);
-  };
+    // generate five new address/private key pairs
+    // the corresponding private keys are also encrypted
+    ks.generateNewAddress(pwDerivedKey, 5);
+    var addr = ks.getAddresses();
 
-  // Now set ks as transaction_signer in the hooked web3 provider
-  // and you can start using web3 using the keys/addresses in ks!
+    ks.passwordProvider = function (callback) {
+      var pw = prompt("Please enter password", "Password");
+      callback(null, pw);
+    };
+
+    // Now set ks as transaction_signer in the hooked web3 provider
+    // and you can start using web3 using the keys/addresses in ks!
+  });
 });
 ```
 
-Sample old-style usage with hooked web3 provider:
+Sample old-style usage with hooked web3 provider (still works, but less secure because uses fixed salts).
 
 ```js
 // generate a new BIP32 12-word seed
@@ -113,13 +120,23 @@ The current recommended keystore construction method. Has popular defaults, hand
 * salt: (optional) The user may supply the salt used to encrypt & decrypt the vault, otherwise a random salt will be generated.
 * hdPathString: (optional) The user may provide a `BIP39` compliant HD Path String. The default is `m/0'/0'/0'`.
 
-### `keystore.deriveKeyFromPassword(password, callback)`
+### `keystore.keyFromPassword(password, callback)`
 
-Inputs the users password and generates a symmetric key of type `Uint8Array` that is used to encrypt/decrypt the keystore.
+This instance method uses any internally-configured salt to return the appropriate `pwDerivedKey`.
 
-### `keystore(seed, pwDerivedKey [,hdPathString])`
+Takes the user's password as input and generates a symmetric key of type `Uint8Array` that is used to encrypt/decrypt the keystore.
+
+### `keystore.deriveKeyFromPassword(password, callback)` (deprecated)
+
+Deprecated class method that uses a fixed salt to derive a `pwDerivedKey` from a password.
+
+Takes the user's password as input and generates a symmetric key of type `Uint8Array` that is used to encrypt/decrypt the keystore.
+
+### `keystore(seed, pwDerivedKey [,hdPathString])` (deprecated)
 
 Constructor of the keystore object. The seed `seed` is encrypted with `pwDerivedKey` and stored encrypted in the keystore.
+
+This method has been deprecated because it relies on a hard-coded salt, but still exists for backwards-compatibility.
 
 #### Inputs
 

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -444,7 +444,6 @@ KeyStore.prototype.exportPrivateKey = function (address, pwDerivedKey, hdPathStr
 
   var address = strip0x(address);
   if (this.ksData[hdPathString].encPrivKeys[address] === undefined) {
-    console.dir(this.ksData)
     throw new Error('KeyStore.exportPrivateKey: Address not found in KeyStore');
   }
 

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -91,8 +91,6 @@ KeyStore.prototype.init = function(mnemonic, pwDerivedKey, hdPathString, salt) {
   pathKsData.addresses = [];
 
   if ( (typeof pwDerivedKey !== 'undefined') && (typeof mnemonic !== 'undefined') ){
-    this.pwDerivedKey = pwDerivedKey
-
     var words = mnemonic.split(' ');
     if (!Mnemonic.isValid(mnemonic, Mnemonic.Words.ENGLISH) || words.length !== 12){
       throw new Error('KeyStore: Invalid mnemonic');
@@ -463,12 +461,6 @@ KeyStore.prototype.exportPrivateKey = function (address, pwDerivedKey, hdPathStr
 
 KeyStore.prototype.generateNewAddress = function(pwDerivedKey, n, hdPathString) {
 
-  // If there is only one argument, it should be the index.
-  if (arguments.length <= 1) {
-    pwDerivedKey = this.pwDerivedKey
-    hdPathString = this.defaultHdPathString
-  }
-
   if(!this.isDerivedKeyCorrect(pwDerivedKey)) {
     throw new Error("Incorrect derived key!");
   }
@@ -541,6 +533,38 @@ KeyStore.prototype.getPubKeys = function (hdPathString) {
   }
 
   return this.ksData[hdPathString].pubKeys;
+}
+
+deriveKeyFromPasswordAndSalt = function(password, salt, callback) {
+
+  // Do not require salt, and default it to 'lightwalletSalt'
+  // (for backwards compatibility)
+  if (!callback && typeof salt === 'function') {
+    callback = salt
+    salt = defaultSalt
+  } else if (!salt && typeof callback === 'function') {
+    salt = defaultSalt
+  }
+
+  var logN = 14;
+  var r = 8;
+  var dkLen = 32;
+  var interruptStep = 200;
+
+  var cb = function(derKey) {
+    try{
+      var ui8arr = (new Uint8Array(derKey));
+      callback(null, ui8arr);
+    } catch (err) {
+      callback(err);
+    }
+  }
+
+  scrypt(password, salt, logN, r, dkLen, interruptStep, cb, null);
+}
+
+KeyStore.prototype.keyFromPassword = function(password, callback) {
+  deriveKeyFromPasswordAndSalt(password, this.salt, callback);
 }
 
 KeyStore.deriveKeyFromPassword = function(password, salt, callback) {

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -12,6 +12,9 @@ var scrypt = require('scrypt-async');
 var encryption = require('./encryption');
 var signing = require('./signing');
 
+var defaultSalt = 'lightwalletSalt'
+var defaultHdPathString = "m/0'/0'/0'";
+
 function strip0x (input) {
   if (typeof(input) !== 'string') {
     return input;
@@ -57,17 +60,22 @@ function nacl_decodeHex(msgHex) {
 }
 
 
-var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
-
-  this.defaultHdPathString = "m/0'/0'/0'";
+var KeyStore = function(mnemonic, pwDerivedKey, hdPathString, salt) {
 
   if (hdPathString === undefined) {
-    hdPathString = this.defaultHdPathString;
+    hdPathString = defaultHdPathString;
   }
-  else {
-    this.defaultHdPathString = hdPathString;    
-  }
+  this.defaultHdPathString = hdPathString;
 
+  if (salt === undefined) {
+    salt = defaultSalt
+  }
+  this.salt = salt
+
+  this.init(mnemonic, pwDerivedKey, hdPathString, salt);
+};
+
+KeyStore.prototype.init = function(mnemonic, pwDerivedKey, hdPathString, salt) {
   this.ksData = {};
   this.ksData[hdPathString] = {};
   var pathKsData = this.ksData[hdPathString];
@@ -83,6 +91,7 @@ var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
   pathKsData.addresses = [];
 
   if ( (typeof pwDerivedKey !== 'undefined') && (typeof mnemonic !== 'undefined') ){
+    this.pwDerivedKey = pwDerivedKey
 
     var words = mnemonic.split(' ');
     if (!Mnemonic.isValid(mnemonic, Mnemonic.Words.ENGLISH) || words.length !== 12){
@@ -91,7 +100,7 @@ var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
 
     // Pad the seed to length 120 before encrypting
     var paddedSeed = leftPadString(mnemonic, ' ', 120);
-    this.encSeed = KeyStore._encryptString(paddedSeed, pwDerivedKey);
+    this.encSeed = encryptString(paddedSeed, pwDerivedKey);
 
     // hdRoot is the relative root from which we derive the keys using
     // generateNewAddress(). The derived keys are then
@@ -102,13 +111,48 @@ var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
     // for standard Ethereum accounts.
 
     var hdRoot = new Mnemonic(mnemonic).toHDPrivateKey().xprivkey;
-    this.encHdRootPriv = KeyStore._encryptString(hdRoot, pwDerivedKey);
+    this.encHdRootPriv = encryptString(hdRoot, pwDerivedKey);
 
     var hdRootKey = new bitcore.HDPrivateKey(hdRoot);
     var hdPath = hdRootKey.derive(hdPathString).xprivkey;
-    pathKsData.encHdPathPriv = KeyStore._encryptString(hdPath, pwDerivedKey);
+    pathKsData.encHdPathPriv = encryptString(hdPath, pwDerivedKey);
   }
+}
+
+KeyStore.createVault = function(opts, cb) {
+  var _this = this;
+
+  // Default hdPathString
+  if (!('hdPathString' in opts)) {
+    opts.hdPathString = "m/0'/0'/0'";
+  }
+
+  // Default seed phrase if not specified
+  if (!('seedPhrase' in opts)) {
+    opts.seedPhrase = this.generateRandomSeed();
+  }
+
+  if (!('salt' in opts)) {
+    opts.salt = defaultSalt;
+  }
+  this.salt = opts.salt
+
+  this.deriveKeyFromPassword(opts.password, opts.salt, function(err, pwDerivedKey) {
+    if (err) return cb(err);
+
+    var ks = new _this(opts.seedPhrase, pwDerivedKey, opts.hdPathString, opts.salt);
+    ks.setDefaultHdDerivationPath(opts.hdPathString);
+    ks.init(opts.seedPhrase, pwDerivedKey, opts.hdPathString, opts.salt);
+
+    cb(null, ks);
+  });
 };
+
+KeyStore.generateSalt = generateSalt;
+
+function generateSalt (byteCount) {
+  return bitcore.crypto.Random.getRandomBuffer(byteCount || 12).toString('base64');
+}
 
 KeyStore.prototype.isDerivedKeyCorrect = function(pwDerivedKey) {
 
@@ -121,14 +165,14 @@ KeyStore.prototype.isDerivedKeyCorrect = function(pwDerivedKey) {
 
 };
 
-KeyStore._encryptString = function (string, pwDerivedKey) {
-
+function encryptString (string, pwDerivedKey) {
   var nonce = nacl.randomBytes(nacl.secretbox.nonceLength);
   var encObj = nacl.secretbox(nacl.util.decodeUTF8(string), nonce, pwDerivedKey);
   var encString = { 'encStr': nacl.util.encodeBase64(encObj),
                     'nonce': nacl.util.encodeBase64(nonce)};
   return encString;
 };
+KeyStore._encryptString = encryptString
 
 KeyStore._decryptString = function (encryptedStr, pwDerivedKey) {
 
@@ -215,7 +259,7 @@ KeyStore.prototype.addHdDerivationPath = function (hdPathString, pwDerivedKey, i
 
   this.ksData[hdPathString] = {};
   this.ksData[hdPathString].info = info;
-  this.ksData[hdPathString].encHdPathPriv = KeyStore._encryptString(hdPath, pwDerivedKey);
+  this.ksData[hdPathString].encHdPathPriv = encryptString(hdPath, pwDerivedKey);
   this.ksData[hdPathString].hdIndex = 0;
   this.ksData[hdPathString].encPrivKeys = {};
 
@@ -348,6 +392,7 @@ KeyStore.deserialize = function (keystore) {
   keystoreX.encSeed       = jsonKS.encSeed;
   keystoreX.encHdRootPriv = jsonKS.encHdRootPriv;
   keystoreX.ksData        = jsonKS.ksData;
+  keystoreX.salt          = jsonKS.salt || defaultSalt;
 
   // Set the defaultHdPathString to an entry that is actuall in the
   // deserialized key store, otherwise the keystore will operate with
@@ -364,6 +409,7 @@ KeyStore.prototype.serialize = function () {
   var jsonKS = {'encSeed': this.encSeed,
                 'ksData' : this.ksData,
                 'encHdRootPriv' : this.encHdRootPriv,
+                'salt': this.salt || defaultSalt,
                 'version' : this.version};
 
   return JSON.stringify(jsonKS);
@@ -405,6 +451,7 @@ KeyStore.prototype.exportPrivateKey = function (address, pwDerivedKey, hdPathStr
 
   var address = strip0x(address);
   if (this.ksData[hdPathString].encPrivKeys[address] === undefined) {
+    console.dir(this.ksData)
     throw new Error('KeyStore.exportPrivateKey: Address not found in KeyStore');
   }
 
@@ -415,6 +462,12 @@ KeyStore.prototype.exportPrivateKey = function (address, pwDerivedKey, hdPathStr
 };
 
 KeyStore.prototype.generateNewAddress = function(pwDerivedKey, n, hdPathString) {
+
+  // If there is only one argument, it should be the index.
+  if (arguments.length <= 1) {
+    pwDerivedKey = this.pwDerivedKey
+    hdPathString = this.defaultHdPathString
+  }
 
   if(!this.isDerivedKeyCorrect(pwDerivedKey)) {
     throw new Error("Incorrect derived key!");
@@ -490,9 +543,17 @@ KeyStore.prototype.getPubKeys = function (hdPathString) {
   return this.ksData[hdPathString].pubKeys;
 }
 
-KeyStore.deriveKeyFromPassword = function(password, callback) {
+KeyStore.deriveKeyFromPassword = function(password, salt, callback) {
 
-  var salt = 'lightwalletSalt'; // should we have user-defined salt?
+  // Do not require salt, and default it to 'lightwalletSalt'
+  // (for backwards compatibility)
+  if (!callback && typeof salt === 'function') {
+    callback = salt
+    salt = defaultSalt
+  } else if (!salt && typeof callback === 'function') {
+    salt = defaultSalt
+  }
+
   var logN = 14;
   var r = 8;
   var dkLen = 32;
@@ -549,6 +610,7 @@ KeyStore.prototype.hasAddress = function (address, callback) {
 };
 
 KeyStore.prototype.signTransaction = function (txParams, callback) {
+  var _this = this
 
   var ethjsTxParams = {};
 
@@ -563,10 +625,16 @@ KeyStore.prototype.signTransaction = function (txParams, callback) {
   var txObj = new Transaction(ethjsTxParams);
   var rawTx = txObj.serialize().toString('hex');
   var signingAddress = strip0x(txParams.from);
+  var salt = this.salt || defaultSalt;
   var self = this;
-  this.passwordProvider( function (err, password) {
+  this.passwordProvider( function (err, password, salt) {
     if (err) return callback(err);
-    KeyStore.deriveKeyFromPassword(password, function (err, pwDerivedKey) {
+
+    if (!salt) {
+      salt = _this.salt
+    }
+
+    KeyStore.deriveKeyFromPassword(password, salt, function (err, pwDerivedKey) {
       if (err) return callback(err);
       var signedTx = signing.signTx(self, pwDerivedKey, rawTx, signingAddress, self.defaultHdPathString);
       callback(null, '0x' + signedTx);

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -60,22 +60,19 @@ function nacl_decodeHex(msgHex) {
 }
 
 
-var KeyStore = function(mnemonic, pwDerivedKey, hdPathString, salt) {
+var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
+  console.warn('The new KeyStore constructor has been deprecated in favor of KeyStore.createVault(), and will be removed in a future version. Read issue #109 for info. https://github.com/ConsenSys/eth-lightwallet/issues/109')
 
   if (hdPathString === undefined) {
     hdPathString = defaultHdPathString;
   }
   this.defaultHdPathString = hdPathString;
 
-  if (salt === undefined) {
-    salt = defaultSalt
-  }
-  this.salt = salt
-
-  this.init(mnemonic, pwDerivedKey, hdPathString, salt);
+  this.init(mnemonic, pwDerivedKey, hdPathString, defaultSalt);
 };
 
 KeyStore.prototype.init = function(mnemonic, pwDerivedKey, hdPathString, salt) {
+  this.salt = salt
   this.ksData = {};
   this.ksData[hdPathString] = {};
   var pathKsData = this.ksData[hdPathString];
@@ -133,13 +130,11 @@ KeyStore.createVault = function(opts, cb) {
   if (!('salt' in opts)) {
     opts.salt = defaultSalt;
   }
-  this.salt = opts.salt
 
   this.deriveKeyFromPassword(opts.password, opts.salt, function(err, pwDerivedKey) {
     if (err) return cb(err);
 
-    var ks = new _this(opts.seedPhrase, pwDerivedKey, opts.hdPathString, opts.salt);
-    ks.setDefaultHdDerivationPath(opts.hdPathString);
+    var ks = new _this(opts.seedPhrase, pwDerivedKey, opts.hdPathString);
     ks.init(opts.seedPhrase, pwDerivedKey, opts.hdPathString, opts.salt);
 
     cb(null, ks);

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -128,7 +128,7 @@ KeyStore.createVault = function(opts, cb) {
   }
 
   if (!('salt' in opts)) {
-    opts.salt = defaultSalt;
+    opts.salt = generateSalt(32);
   }
 
   this.deriveKeyFromPassword(opts.password, opts.salt, function(err, pwDerivedKey) {
@@ -144,7 +144,7 @@ KeyStore.createVault = function(opts, cb) {
 KeyStore.generateSalt = generateSalt;
 
 function generateSalt (byteCount) {
-  return bitcore.crypto.Random.getRandomBuffer(byteCount || 12).toString('base64');
+  return bitcore.crypto.Random.getRandomBuffer(byteCount || 32).toString('base64');
 }
 
 KeyStore.prototype.isDerivedKeyCorrect = function(pwDerivedKey) {

--- a/test/fixtures/keystore.json
+++ b/test/fixtures/keystore.json
@@ -1,6 +1,54 @@
 {
   "valid": [
     {"password" : "password",
+     "salt": "strangeSalt",
+     "pwDerivedKey": [205, 127, 41, 55, 40, 243, 95, 138, 187, 239, 244, 242, 33, 239, 174, 4, 146, 184, 75, 185, 221, 160, 223, 207, 124, 49, 16, 208, 237, 141, 15, 120],
+
+      "seed": "77c2b00716cec7213839159e404db50d",
+      "mnSeed": "jelly better achieve collect unaware mountain thought cargo oxygen act hood bridge",
+      "hdIndex": 0,
+      "privKeyHex": "7627f5655d3f103f0be5c90064bd3557995604e6208590986de4e1230425c1ae",
+      "address": "07ed7f762488ffa46298afeba33f05a04c796833",
+      "ethjsTxParams" : {"from" : "0x07ed7f762488ffa46298afeba33f05a04c796833",
+                        "to" : "0x9e2068cce22de4e1e80f15cb71ef435a20a3b37c",
+                        "nonce" : "0x00",
+                        "value" : "0xde0b6b3a7640000",
+                        "gasLimit" : "0x2fefd8",
+                        "gasPrice" : "0xba43b7400",
+                       "data" : "0xabcdef01234567890"},
+     "web3TxParams" : {"from" : "0x07ed7f762488ffa46298afeba33f05a04c796833",
+                        "to" : "0x9e2068cce22de4e1e80f15cb71ef435a20a3b37c",
+                        "nonce" : "0x00",
+                        "value" : "0xde0b6b3a7640000",
+                        "gas" : "0x2fefd8",
+                        "gasPrice" : "0xba43b7400",
+                       "data" : "0xabcdef01234567890"},
+     "rawUnsignedTx" : "f680850ba43b7400832fefd8949e2068cce22de4e1e80f15cb71ef435a20a3b37c880de0b6b3a7640000890abcdef012345678901c8080",
+     "rawSignedTx" : "f87680850ba43b7400832fefd8949e2068cce22de4e1e80f15cb71ef435a20a3b37c880de0b6b3a7640000890abcdef012345678901ca08de63b51b4b9cc5bc09f7f9610d707f43c5840b37dffe655d0073b270032511ba01c31647c5cb6d32676e73bd0ea618fa9f3fa2a7c0132e11a593b2e44cc500323",
+      "m/0'/0'/1'" : {"addresses" : [ "d540ec8e4de76484e31cdce612f1d4da196e6987",
+                                      "f65f355fd6c0771a9fa9dc31191dcafe1cc79934",
+                                      "1fb2a56e077aa64236623baea6fae20c6209d885",
+                                      "3c2b55c8019eec2ceea5154cc6d150e877a68a69",
+                                      "ee77f5a7f61ff11b8734c043db0ed5bc7afd8447" ]},
+
+      "m/0'/0'/5'" : {"addresses" : [ "427bfa1ebd65dd5a136ed3112fe5f72e7cebe43a",
+                                      "a4c2f35340307e50b453ccd6574db054d2ef357a",
+                                      "618c683268c1c2a75f28e158943977e81b7568a1",
+                                      "060e9bb7211af94a13f2d09cec767d5d2ca4acc1",
+                                      "558e33b4272da4b004470a4ada4e673cc972379a",
+                                      "6b85cc8f612d5457d49775439335f83e12b8cfde",
+                                      "cbd22ff1ded1423fbc24a7af2148745878800024" ]},
+
+     "m/0'/0'/2'" : {"pubKeys" : ["9b2b6699ad63eaf4f08c5a16d29eaf9db40dfb47b6c41d16bb00368564b76f10",
+                                  "eaa70a8727385e6e0af7ce718874065a3cba0b994555543288b79901e320be20",
+                                  "70d505a34e1ff438a6e0fca3ba37ba8e3c7d7b9843a5762b45d3be9e4d38633f",
+                                  "7c2864ef868146251c881d2cb4e92cab3a1868bb3fc49b233a4471dcb1bc050e",
+                                  "9c493f840b54cb4d48c1dbc8dacf4b7fa6a471e4f462eae3f64ebf10fcd9430c",
+                                  "170023f3a4ef99ae36f97bfedb8e55be277755a2b1b8caa35067cfe93e467b1d" ]}
+
+    },
+    {"password" : "password",
+     "salt": "lightwalletSalt",
      "pwDerivedKey" : [12, 37, 184, 176, 141, 255, 15, 70, 189, 195, 206, 218, 109, 172, 141, 233, 117, 114, 2, 10, 156, 57, 255, 102, 37, 66, 2, 177, 82, 70, 1, 246],
 
       "seed": "77c2b00716cec7213839159e404db50d",
@@ -49,6 +97,7 @@
     },
 
     {"password" : "asdflknwqeroilasdflkjnzvmnwmet",
+     "salt": "lightwalletSalt",
      "pwDerivedKey" : [24,100,147,66,23,117,206,186,27,54,254,137,187,174,103,5,38,18,139,128,139,74,217,188,166,34,0,30,54,133,158,208],
       "seed": "0460ef47585604c5660618db2e6a7e7f",
       "mnSeed": "afford alter spike radar gate glance object seek swamp infant panel yellow",
@@ -58,6 +107,7 @@
     },
 
     {"password" : "!@&#*#()",
+     "salt": "lightwalletSalt",
      "pwDerivedKey" : [51,238,218,224,61,216,29,19,249,245,254,125,54,245,160,253,1,73,137,234,137,138,109,226,61,11,128,41,76,115,80,43],
       "seed": "eaebabb2383351fd31d703840b32e9e2",
       "mnSeed": "turtle front uncle idea crush write shrug there lottery flower risk shell",
@@ -68,6 +118,7 @@
 
     {
       "password" : "PassHello",
+      "salt": "lightwalletSalt",
       "pwDerivedKey" : [113,91,117,133,102,129,128,16,251,116,91,122,215,255,183,202,72,108,222,129,238,46,143,236,132,13,127,227,110,202,254,112],
       "seed": "18ab19a9f54a9274f03e5209a2ac8a91",
       "mnSeed": "board flee heavy tunnel powder denial science ski answer betray cargo cat",
@@ -98,6 +149,5 @@
       "ent1" : "c",
       "targetHash" : "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
     }
-    
   ]
 }

--- a/test/keystore.js
+++ b/test/keystore.js
@@ -336,17 +336,20 @@ describe("Keystore", function() {
         seedPhrase: fixture.mnSeed,
         salt: fixture.salt,
       }, function (err, ks) {
-        ks.generateNewAddress(1)
-        var addr = ks.getAddresses()[0]
 
-        // Trivial passwordProvider
-        ks.passwordProvider = function(callback) {callback(null, fixture.password)}
+        ks.keyFromPassword(fixture.password, function(err, pwDerivedKey) {
+          ks.generateNewAddress(pwDerivedKey, 1)
+          var addr = ks.getAddresses()[0]
 
-        var txParams = fixture.web3TxParams
-        ks.signTransaction(txParams, function (err, signedTx) {
-          expect(signedTx.slice(2)).to.equal(fixture.rawSignedTx)
-          done();
-        });
+          // Trivial passwordProvider
+          ks.passwordProvider = function(callback) {callback(null, fixture.password)}
+
+          var txParams = fixture.web3TxParams
+          ks.signTransaction(txParams, function (err, signedTx) {
+            expect(signedTx.slice(2)).to.equal(fixture.rawSignedTx)
+            done();
+          });
+        })
       });
     });
 


### PR DESCRIPTION
- Added `KeyStore.newVault(opts, cb)` method that generates a salt for the vault by default.
- Added the salt value to the serialization & deserialization.
- Added new keystore instance `keyForPassword(password, cb)` method that uses internally defined salts, unlike the old class method that required the salt to be passed in manually.

Fixes #109 per our latest discussions on how a solution might work.