### PR TITLE
Hide deprecation warning with createVault constructor

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -59,9 +59,11 @@ function nacl_decodeHex(msgHex) {
   return nacl.util.decodeBase64(msgBase64);
 }
 
-
+var newMode = false
 var KeyStore = function(mnemonic, pwDerivedKey, hdPathString) {
-  console.warn('The new KeyStore constructor has been deprecated in favor of KeyStore.createVault(), and will be removed in a future version. Read issue #109 for info. https://github.com/ConsenSys/eth-lightwallet/issues/109')
+  if (!newMode) {
+    console.warn('The new KeyStore constructor has been deprecated in favor of KeyStore.createVault(), and will be removed in a future version. Read issue #109 for info. https://github.com/ConsenSys/eth-lightwallet/issues/109')
+  }
 
   if (hdPathString === undefined) {
     hdPathString = defaultHdPathString;
@@ -134,7 +136,10 @@ KeyStore.createVault = function(opts, cb) {
   this.deriveKeyFromPassword(opts.password, opts.salt, function(err, pwDerivedKey) {
     if (err) return cb(err);
 
+    newMode = true
     var ks = new _this(opts.seedPhrase, pwDerivedKey, opts.hdPathString);
+    newMode = false
+
     ks.init(opts.seedPhrase, pwDerivedKey, opts.hdPathString, opts.salt);
 
     cb(null, ks);


### PR DESCRIPTION
This is a cleanup patch from the new constructor feature.

The `KeyStore.createVault` method relies on the underlying `new` constructor, which we have issuing a deprecation warning, so now that warning is actually firing always.

We were talking about getting rid of the `new` method eventually, but to actually stop using it while most of its methods are instance methods on the prototype would require a bit of a refactor.

This is a cheap solution that avoids that refactor for the moment.

In the slightly longer term, we might want to make the current KeyStore class simply return another internal class, so it can use the `new` constructor internally, while only throwing the deprecation warning when its own new constructor is used.

I'm opening to making that change to this PR, but wanted to open the discussion first.
