### PR TITLE
Remove deserialize deprecation warning

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -385,7 +385,9 @@ KeyStore.deserialize = function (keystore) {
   }
 
   // Create keystore
+  newMode = true;
   var keystoreX = new KeyStore();
+  newMode = false;
 
   keystoreX.encSeed       = jsonKS.encSeed;
   keystoreX.encHdRootPriv = jsonKS.encHdRootPriv;


### PR DESCRIPTION
Disable the deprecation warning using the `newMode` variable as done elsewhere.

Addresses https://github.com/ConsenSys/eth-lightwallet/issues/123