### PR TITLE
Remove bignumber dependency. Temporary fix for broken web3.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes #
 
+## Version 2.5.5 - 2017-06-23 ##
+
+* Remove redundant dependency on `bignumber.js` library which has stopped working. Temporarily use a fork of `web3.js` since this library also breaks because of the issues with the `bignumber.js` library. 
+
 ## Version 2.5.4 - 2017-03-16 ##
 
 * Upgrade bitcore-lib and explicitly increase version of bitcore-mnemonic. By [roderik](https://github.com/roderik).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-lightwallet",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "A lightweight ethereum javascript wallet.",
   "main": "index.js",
   "repository": {
@@ -56,7 +56,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bignumber.js": "debris/bignumber.js#94d7146671b9719e00a09c29b01a691bc85048c2",
     "bitcore-lib": "^0.14.0",
     "bitcore-mnemonic": "^1.2.2",
     "buffer": "^4.9.0",
@@ -67,7 +66,7 @@
     "rlp": "^2.0.0",
     "scrypt-async": "^1.2.0",
     "tweetnacl": "0.13.2",
-    "web3": "^0.15.3"
+    "web3": "shayanb/web3.js#develop"
   },
   "devDependencies": {
     "async": "^1.4.2",


### PR DESCRIPTION
Removed the dependency on the broken `bignumber.js` library. This also broke `web3` so I'm including temporarily a fixed PR of `web3`.