### PR TITLE
removes salt from serialize

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -304,7 +304,7 @@ KeyStore.isSeedValid = function(seed) {
 };
 
 // Takes keystore serialized as string and returns an instance of KeyStore
-KeyStore.deserialize = function (keystore,salt) {
+KeyStore.deserialize = function (keystore) {
   var jsonKS = JSON.parse(keystore);
 
   if (jsonKS.version === undefined || jsonKS.version !== 3) {
@@ -314,7 +314,6 @@ KeyStore.deserialize = function (keystore,salt) {
   // Create keystore
   var keystoreX = new KeyStore();
 
-  keystoreX.salt = salt;
   keystoreX.hdPathString = jsonKS.hdPathString;
   keystoreX.encSeed = jsonKS.encSeed;
   keystoreX.encHdRootPriv = jsonKS.encHdRootPriv;


### PR DESCRIPTION
This makes the serialized vault more secure, from my point of view it makes no sense to store the salt in the wallets instance. as anyone with accesses to this has accesses to salt. 

Additionally, if you provide salt manually this can open the door for more interesting scenarios for unlocking the vault, for example, 2fa or 2-way response. 

Is there a reason why salt is part of the instance from what I see it should be stored separately or at least given an option to store in a more secure sense.
