### PR TITLE
Remove 12 word restriction from wallet

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -303,7 +303,7 @@ KeyStore.isSeedValid = function(seed) {
 };
 
 // Takes keystore serialized as string and returns an instance of KeyStore
-KeyStore.deserialize = function (keystore) {
+KeyStore.deserialize = function (keystore,salt) {
   var jsonKS = JSON.parse(keystore);
 
   if (jsonKS.version === undefined || jsonKS.version !== 3) {
@@ -313,8 +313,8 @@ KeyStore.deserialize = function (keystore) {
   // Create keystore
   var keystoreX = new KeyStore();
 
-  keystoreX.salt = jsonKS.salt
-  keystoreX.hdPathString = jsonKS.hdPathString
+  keystoreX.salt = salt;
+  keystoreX.hdPathString = jsonKS.hdPathString;
   keystoreX.encSeed = jsonKS.encSeed;
   keystoreX.encHdRootPriv = jsonKS.encHdRootPriv;
   keystoreX.version = jsonKS.version;
@@ -363,7 +363,6 @@ KeyStore.prototype.serialize = function () {
                 'addresses' : this.addresses,
                 'encPrivKeys' : this.encPrivKeys,
                 'hdPathString' : this.hdPathString,
-                'salt': this.salt,
                 'hdIndex' : this.hdIndex,
                 'version' : this.version};
 

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -71,7 +71,7 @@ KeyStore.prototype.init = function(mnemonic, pwDerivedKey, hdPathString, salt) {
 
   if ( (typeof pwDerivedKey !== 'undefined') && (typeof mnemonic !== 'undefined') ){
     var words = mnemonic.split(' ');
-    if (!Mnemonic.isValid(mnemonic, Mnemonic.Words.ENGLISH) || words.length !== 12){
+    if (!Mnemonic.isValid(mnemonic, Mnemonic.Words.ENGLISH)){
       throw new Error('KeyStore: Invalid mnemonic');
     }
 

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -279,11 +279,12 @@ KeyStore._concatAndSha256 = function(entropyBuf0, entropyBuf1) {
 // If extraEntropy is not set, the random number generator
 // is used directly.
 
-KeyStore.generateRandomSeed = function(extraEntropy) {
-
+KeyStore.generateRandomSeed = function(extraEntropy,entropyStrength) {
+ 
   var seed = '';
+  var entropy = entropyStrength ? entropyStrength : 128;
   if (extraEntropy === undefined) {
-    seed = new Mnemonic(Mnemonic.Words.ENGLISH);
+    seed = new Mnemonic(entropy,Mnemonic.Words.ENGLISH);
   }
   else if (typeof extraEntropy === 'string') {
     var entBuf = new Buffer(extraEntropy);


### PR DESCRIPTION
There is, in reality, no need for the 12-word check currently done in the light wallet the Mnemonic library `isValid` takes care of that and it is better to open the opportunity for generating different word combinations based on BIP39