### PR TITLE
https://github.com/ConsenSys/eth-lightwallet/issues/182: createVault …

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -111,9 +111,12 @@ KeyStore.createVault = function(opts, cb) {
     if (err) return cb(err);
 
     var ks = new KeyStore();
-    ks.init(opts.seedPhrase, pwDerivedKey, opts.hdPathString, opts.salt);
-
-    cb(null, ks);
+    try{
+      ks.init(opts.seedPhrase, pwDerivedKey, opts.hdPathString, opts.salt);
+      cb(null, ks);
+    } catch(err) {
+      cb(err, null);
+    }
   });
 };
 


### PR DESCRIPTION
At present if init function throws error if invalid mnemonic occurs which is not caught by createVault function. This results in end users unable to handle that error. Wrapping the call to init function with try catch and passing err to callback if error comes will allow users to gracefully handle the situation.