### PR TITLE
value of interruptStep raised to reduce the setTimeout calls

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -339,7 +339,7 @@ KeyStore.deriveKeyFromPasswordAndSalt = function(password, salt, callback) {
   var logN = 14;
   var r = 8;
   var dkLen = 32;
-  var interruptStep = 200;
+  var interruptStep = 2000;
 
   var cb = function(derKey) {
     var err = null


### PR DESCRIPTION
Using [scrypt-async-js library](https://github.com/dchest/scrypt-async-js) can cause an incredible amount of setTimeouts calls. On weaker devices this can lead to the browser only executing the callback of the setTimeouts after 10 - 80 seconds.

With an adjusted "interruptStep" value the number of setTimeouts can be drastically reduced.

https://github.com/ConsenSys/eth-lightwallet/issues/200