### PR TITLE
Refactor buffer constructor

### DIFF
--- a/lib/encryption.js
+++ b/lib/encryption.js
@@ -3,11 +3,11 @@ var nacl = require('tweetnacl');
 
 function nacl_encodeHex(msgUInt8Arr) {
   var msgBase64 = nacl.util.encodeBase64(msgUInt8Arr);
-  return (new Buffer(msgBase64, 'base64')).toString('hex');
+  return (Buffer.from(msgBase64, 'base64')).toString('hex');
 }
 
 function nacl_decodeHex(msgHex) {
-  var msgBase64 = (new Buffer(msgHex, 'hex')).toString('base64');
+  var msgBase64 = (Buffer.from(msgHex, 'hex')).toString('base64');
   return nacl.util.decodeBase64(msgBase64);
 }
 

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -48,11 +48,11 @@ function leftPadString (stringToPad, padChar, length) {
 
 function nacl_encodeHex(msgUInt8Arr) {
   var msgBase64 = nacl.util.encodeBase64(msgUInt8Arr);
-  return (new Buffer(msgBase64, 'base64')).toString('hex');
+  return (Buffer.from(msgBase64, 'base64')).toString('hex');
 }
 
 function nacl_decodeHex(msgHex) {
-  var msgBase64 = (new Buffer(msgHex, 'hex')).toString('base64');
+  var msgBase64 = (Buffer.from(msgHex, 'hex')).toString('base64');
   return nacl.util.decodeBase64(msgBase64);
 }
 
@@ -199,11 +199,11 @@ KeyStore._computePubkeyFromPrivKey = function (privKey, curve) {
     throw new Error('KeyStore._computePubkeyFromPrivKey: Only "curve25519" supported.')
   }
 
-  var privKeyBase64 = (new Buffer(privKey, 'hex')).toString('base64')
+  var privKeyBase64 = (Buffer.from(privKey, 'hex')).toString('base64')
   var privKeyUInt8Array = nacl.util.decodeBase64(privKeyBase64);
   var pubKey = nacl.box.keyPair.fromSecretKey(privKeyUInt8Array).publicKey;
   var pubKeyBase64 = nacl.util.encodeBase64(pubKey);
-  var pubKeyHex = (new Buffer(pubKeyBase64, 'base64')).toString('hex');
+  var pubKeyHex = (Buffer.from(pubKeyBase64, 'base64')).toString('hex');
 
   return pubKeyHex;
 }
@@ -286,7 +286,7 @@ KeyStore.generateRandomSeed = function(extraEntropy) {
     seed = new Mnemonic(Mnemonic.Words.ENGLISH);
   }
   else if (typeof extraEntropy === 'string') {
-    var entBuf = new Buffer(extraEntropy);
+    var entBuf = Buffer.from(extraEntropy);
     var randBuf = Random.getRandomBuffer(256 / 8);
     var hashedEnt = this._concatAndSha256(randBuf, entBuf).slice(0, 128 / 8);
     seed = new Mnemonic(hashedEnt, Mnemonic.Words.ENGLISH);

--- a/lib/signing.js
+++ b/lib/signing.js
@@ -10,11 +10,11 @@ var signTx = function (keystore, pwDerivedKey, rawTx, signingAddress) {
   rawTx = util.stripHexPrefix(rawTx);
   signingAddress = util.stripHexPrefix(signingAddress);
 
-  var txCopy = new Transaction(new Buffer(rawTx, 'hex'));
+  var txCopy = new Transaction(Buffer.from(rawTx, 'hex'));
 
   var privKey = keystore.exportPrivateKey(signingAddress, pwDerivedKey);
 
-  txCopy.sign(new Buffer(privKey, 'hex'));
+  txCopy.sign(Buffer.from(privKey, 'hex'));
   privKey = '';
 
   return txCopy.serialize().toString('hex');
@@ -44,7 +44,7 @@ var signMsgHash = function (keystore, pwDerivedKey, msgHash, signingAddress) {
 
   var privKey = keystore.exportPrivateKey(signingAddress, pwDerivedKey);
 
-  return util.ecsign(new Buffer(util.stripHexPrefix(msgHash), 'hex'), new Buffer(privKey, 'hex'));
+  return util.ecsign(Buffer.from(util.stripHexPrefix(msgHash), 'hex'), Buffer.from(privKey, 'hex'));
 };
 
 module.exports.signMsgHash = signMsgHash;

--- a/lib/txutils.js
+++ b/lib/txutils.js
@@ -72,7 +72,7 @@ function functionTx (abi, functionName, args, txObject) {
 }
 
 function createdContractAddress (fromAddress, nonce) {
-  var rlpEncodedHex = rlp.encode([new Buffer(strip0x(fromAddress), 'hex'), nonce]).toString('hex');
+  var rlpEncodedHex = rlp.encode([Buffer.from(strip0x(fromAddress), 'hex'), nonce]).toString('hex');
   var rlpEncodedWordArray = CryptoJS.enc.Hex.parse(rlpEncodedHex);
   var hash = CryptoJS.SHA3(rlpEncodedWordArray, {outputLength: 256}).toString(CryptoJS.enc.Hex);
 

--- a/test/keystore.js
+++ b/test/keystore.js
@@ -293,8 +293,8 @@ describe("Keystore", function() {
 
       var N = fixtures.sha256Test.length;
       for (var i=0; i<N; i++) {
-        var ent0 = new Buffer(fixtures.sha256Test[i].ent0);
-        var ent1 = new Buffer(fixtures.sha256Test[i].ent1);
+        var ent0 = Buffer.from(fixtures.sha256Test[i].ent0);
+        var ent1 = Buffer.from(fixtures.sha256Test[i].ent1);
         var outputString = keyStore._concatAndSha256(ent0, ent1).toString('hex');
         expect(outputString).to.equal(fixtures.sha256Test[i].targetHash);
       }


### PR DESCRIPTION
#### What does it do?
This PR replaces all `new Buffer` with `Buffer.from`. We should not use Buffer constructor which is deprecated and unsafe.

#### Any helpful background information?
The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe