### PR TITLE
Fixed deprecated async loading path

### DIFF
--- a/example/webwallet.html
+++ b/example/webwallet.html
@@ -3,7 +3,7 @@
     <script src="../dist/lightwallet.min.js"></script>
     <script src="../node_modules/web3/dist/web3.js" type="text/javascript"></script>
     <script src="../node_modules/hooked-web3-provider/build/hooked-web3-provider.js" type="text/javascript"></script>
-    <script src="../node_modules/async/lib/async.js" type="text/javascript"></script>
+    <script src="../node_modules/async/dist/async.js" type="text/javascript"></script>
     <script>
       var web3 = new Web3();
       var global_keystore;


### PR DESCRIPTION
Async library has modified the path to the `async.js` lib as we can see from their [github repo](https://github.com/caolan/async/tree/master/dist). 

This PR intends to adapt the usage of the async lib within the webwallet.html example