### PR TITLE
Fix typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Recovers the signing address from the message `rawMsg` and the signature `v, r, 
 
 **NOTE:** The format of encrypted messages has not been finalized and may change at any time, so only use this for ephemeral messages that do not need to be stored encrypted for a long time.
 
-Encrypts the string `msg` with a randomly generated symmetric key, then encrypts that symmetric key assymetrically to each of the pubkeys in `theirPubKeyArray`. The encrypted message can then be read only by sender and the holders of the private keys corresponding to the public keys in `theirPubKeyArray`. The returned object has the following form, where nonces and ciphertexts are encoded in base64:
+Encrypts the string `msg` with a randomly generated symmetric key, then encrypts that symmetric key asymmetrically to each of the pubkeys in `theirPubKeyArray`. The encrypted message can then be read only by sender and the holders of the private keys corresponding to the public keys in `theirPubKeyArray`. The returned object has the following form, where nonces and ciphertexts are encoded in base64:
 
 ```js
 { version: 1,


### PR DESCRIPTION
There is a typo in the README file ("assymetrically")
The spelling should be updated to "asymmetrically"